### PR TITLE
Handled empty catch block in isCrashReportingProcess()

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/Startup.java
+++ b/src/main/java/de/dennisguse/opentracks/Startup.java
@@ -63,7 +63,8 @@ public class Startup extends Application {
                 Class<?> activityThread = Class.forName("android.app.ActivityThread");
                 @SuppressLint("DiscouragedPrivateApi") Method getProcessName = activityThread.getDeclaredMethod("currentProcessName");
                 processName = (String) getProcessName.invoke(null);
-            } catch (Exception ignored) {
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to retrieve process name", e);
             }
         } else {
             processName = Application.getProcessName();


### PR DESCRIPTION
### Summary
- Fixed an empty `catch` block in `isCrashReportingProcess()`.
- Added error logging (`Log.e(TAG, "Failed to retrieve process name", e);`) to improve debugging and maintainability.

### Why This Change?
- Empty `catch` blocks introduce ambiguity and make debugging difficult.
- Logging the exception ensures errors are properly tracked and handled.

### Impact
- Improves code readability and maintainability.
- No functional impact; just better error handling.
