### PR TITLE
Solved the technical debt - use isEmpty instead of size

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
@@ -883,7 +883,7 @@ public class ChartView extends View {
                 break;
             }
         }
-        if (firstChartValueSeries != null && chartPoints.size() > 0) {
+        if (firstChartValueSeries != null && !chartPoints.isEmpty()) {
             int dx = getX(maxX) - pointer.getIntrinsicWidth() / 2;
             double value = firstChartValueSeries.extractDataFromChartPoint(last);
             int dy = getY(firstChartValueSeries, value) - pointer.getIntrinsicHeight();


### PR DESCRIPTION
### Summary

- Refactored size() > 0 to isEmpty() in collection checks to improve readability and efficiency.
- Updated condition in the affected file (ChartView.java, Line 886) to align with best practices.
### Why This Change?

- Using isEmpty() instead of size() > 0 makes the intent clearer and improves maintainability.
- size() can have O(n) complexity in some collection types, whereas isEmpty() is O(1), making it more efficient.
- Aligns with SonarQube rule Java:S1155, reducing unnecessary comparisons.
### Impact

- Improves code readability and maintainability.
- Enhances performance in certain collection implementations.
- No functional impact; just a refactor for better clarity and efficiency.