### PR TITLE
Remove code duplication between TrackListAdapter and MarkerListAdapter

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/ui/TrackListAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/TrackListAdapter.java
@@ -36,6 +36,7 @@ import de.dennisguse.opentracks.ui.util.ActivityUtils;
 import de.dennisguse.opentracks.ui.util.ListItemUtils;
 import de.dennisguse.opentracks.util.IntentUtils;
 import de.dennisguse.opentracks.util.StringUtils;
+import de.dennisguse.opentracks.ui.util.SelectionUtils;
 
 public class TrackListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements ActionMode.Callback {
 
@@ -131,35 +132,23 @@ public class TrackListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         actionModeCallback.onDestroy();
     }
 
-    public void setAllSelected(boolean isSelected) {
-        if (isSelected) {
-            final int idIndex = cursor.getColumnIndexOrThrow(TracksColumns._ID);
+	public void setAllSelected(boolean isSelected) {
+		if (isSelected) {
+			final int idIndex = cursor.getColumnIndexOrThrow(TracksColumns._ID);
 
-            cursor.moveToFirst();
-            do {
-                selection.put((int) cursor.getLong(idIndex), true);
-            } while (cursor.moveToNext());
-        } else {
-            selection.clear();
-        }
+			cursor.moveToFirst();
+			do {
+				selection.put((int) cursor.getLong(idIndex), true);
+			} while (cursor.moveToNext());
+		}
 
-        for (int i = 0; i < recyclerView.getChildCount(); i++) {
-            ViewHolder holder = (ViewHolder) recyclerView.getChildViewHolder(recyclerView.getChildAt(i));
-            holder.setSelected(isSelected);
-        }
-    }
+		SelectionUtils.updateSelectionStateForVisible(recyclerView, selection, isSelected,
+				(ViewHolder holder, boolean selected) -> holder.setSelected(selected));
+	}
 
-    private long[] getCheckedIds() {
-        List<Long> ids = new ArrayList<>();
-
-        for (int i = 0; i < selection.size(); i++) {
-            if (selection.valueAt(i)) {
-                ids.add((long) selection.keyAt(i));
-            }
-        }
-
-        return ids.stream().mapToLong(i -> i).toArray();
-    }
+	private long[] getCheckedIds() {
+		return SelectionUtils.getCheckedIds(selection);
+	}
 
     public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener, View.OnLongClickListener {
 

--- a/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerListAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerListAdapter.java
@@ -36,6 +36,7 @@ import de.dennisguse.opentracks.ui.util.ListItemUtils;
 import de.dennisguse.opentracks.ui.util.ThemeUtils;
 import de.dennisguse.opentracks.util.IntentUtils;
 import de.dennisguse.opentracks.util.StringUtils;
+import de.dennisguse.opentracks.ui.util.SelectionUtils;
 
 public class MarkerListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements ActionMode.Callback {
 
@@ -134,32 +135,21 @@ public class MarkerListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         actionModeCallback.onDestroy();
     }
 
-    public void setAllSelected(boolean isSelected) {
-        if (isSelected) {
-            for (Marker marker : markers) {
-                selection.put((int) marker.getId().id(), true);
-            }
-        } else {
-            selection.clear();
-        }
+	public void setAllSelected(boolean isSelected) {
+		if (isSelected) {
+			for (Marker marker : markers) {
+				selection.put((int) marker.getId().id(), true);
+			}
+		}
 
-        for (int i = 0; i < recyclerView.getChildCount(); i++) {
-            ViewHolder holder = (ViewHolder) recyclerView.getChildViewHolder(recyclerView.getChildAt(i));
-            holder.setSelected(isSelected);
-        }
-    }
+		SelectionUtils.updateSelectionStateForVisible(recyclerView, selection, isSelected,
+				(ViewHolder holder, boolean selected) -> holder.setSelected(selected));
+	}
 
-    private long[] getCheckedIds() {
-        List<Long> ids = new ArrayList<>();
+	private long[] getCheckedIds() {
 
-        for (int i = 0; i < selection.size(); i++) {
-            if (selection.valueAt(i)) {
-                ids.add((long) selection.keyAt(i));
-            }
-        }
-
-        return ids.stream().mapToLong(i -> i).toArray();
-    }
+		return SelectionUtils.getCheckedIds(selection);
+	}
 
     public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener, View.OnLongClickListener {
 

--- a/src/main/java/de/dennisguse/opentracks/ui/util/SelectionUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/util/SelectionUtils.java
@@ -1,0 +1,63 @@
+package de.dennisguse.opentracks.ui.util;
+
+import android.util.SparseBooleanArray;
+import android.view.View;
+
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for handling selection in RecyclerView adapters.
+ */
+public class SelectionUtils {
+
+    /**
+     * Gets an array of checked IDs from a selection array.
+     * 
+     * @param selection The SparseBooleanArray containing selection state
+     * @return Array of selected IDs
+     */
+    public static long[] getCheckedIds(SparseBooleanArray selection) {
+        List<Long> ids = new ArrayList<>();
+
+        for (int i = 0; i < selection.size(); i++) {
+            if (selection.valueAt(i)) {
+                ids.add((long) selection.keyAt(i));
+            }
+        }
+
+        return ids.stream().mapToLong(i -> i).toArray();
+    }
+
+    /**
+     * Updates all visible child ViewHolders' selection state
+     * 
+     * @param recyclerView The RecyclerView containing ViewHolders
+     * @param selection The SparseBooleanArray to clear if not selected
+     * @param isSelected Whether to select or deselect
+     */
+    public static <T extends RecyclerView.ViewHolder> void updateSelectionStateForVisible(
+            RecyclerView recyclerView,
+            SparseBooleanArray selection,
+            boolean isSelected,
+            SelectionCallback<T> callback) {
+        
+        if (!isSelected) {
+            selection.clear();
+        }
+
+        for (int i = 0; i < recyclerView.getChildCount(); i++) {
+            T holder = (T) recyclerView.getChildViewHolder(recyclerView.getChildAt(i));
+            callback.setSelected(holder, isSelected);
+        }
+    }
+    
+    /**
+     * Callback interface for selection operations
+     */
+    public interface SelectionCallback<T extends RecyclerView.ViewHolder> {
+        void setSelected(T holder, boolean isSelected);
+    }
+}


### PR DESCRIPTION
- Created SelectionUtils class to handle common selection logic
- Extracted duplicated getCheckedIds() method to SelectionUtils
- Extracted common selection update logic for UI recycler views
- Maintained original method signatures to preserve compatibility
- Applied refactoring to fix clone detected by PMD CPD




