### PR TITLE
Refactored PreferencesUtilsTest to remove duplicate profile string logic

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/settings/PreferencesUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/settings/PreferencesUtilsTest.java
@@ -225,23 +225,25 @@ public class PreferencesUtilsTest {
             assertEquals(recordingLayoutSrc.getFields().get(i).isPrimary(), recordingLayoutDst.getFields().get(i).isPrimary());
         }
     }
-
+    
+    private String createProfileString(String profileName, boolean useSpeedKeys) {
+        return profileName + ";2;"
+                + context.getString(R.string.stats_custom_layout_moving_time_key) + ",1,1;"
+                + context.getString(R.string.stats_custom_layout_distance_key) + ",1,1;"
+                + (useSpeedKeys
+                    ? context.getString(R.string.stats_custom_layout_average_moving_speed_key) + ",1,1;"
+                    + context.getString(R.string.stats_custom_layout_speed_key) + ",1,1;"
+                    : context.getString(R.string.stats_custom_layout_average_pace_key) + ",0,0;"
+                    + context.getString(R.string.stats_custom_layout_pace_key) + ",0,0;");
+    }
+    
     @Test
     public void testEditCustomLayouts() {
         // update all custom layouts
 
         // given a custom layout with two profiles
-        String cyclingProfile = "cycling;2;"
-                + context.getString(R.string.stats_custom_layout_moving_time_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_distance_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_average_moving_speed_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_speed_key) + ",1,1;";
-
-        String runningProfile = "running;2;"
-                + context.getString(R.string.stats_custom_layout_moving_time_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_distance_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_average_pace_key) + ",0,0;"
-                + context.getString(R.string.stats_custom_layout_pace_key) + ",0,0;";
+        String cyclingProfile = createProfileString("cycling", true);
+        String runningProfile = createProfileString("running", false);
 
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         SharedPreferences.Editor editor = sharedPreferences.edit();
@@ -251,11 +253,8 @@ public class PreferencesUtilsTest {
         List<RecordingLayout> layoutsBefore = PreferencesUtils.getAllCustomLayouts();
 
         // when cyling profile is updated
-        String cyclingProfileUpdated = "cycling;2;"
-                + context.getString(R.string.stats_custom_layout_moving_time_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_distance_key) + ",0,0;"
-                + context.getString(R.string.stats_custom_layout_average_moving_speed_key) + ",0,0;"
-                + context.getString(R.string.stats_custom_layout_speed_key) + ",0,0;";
+        String cyclingProfileUpdated = createUpdatedProfileString("cycling");
+
 
         List<RecordingLayout> layoutsToBeUpdated = new ArrayList<>();
         layoutsToBeUpdated.add(RecordingLayoutIO.fromCsv(cyclingProfileUpdated, resources));
@@ -278,17 +277,8 @@ public class PreferencesUtilsTest {
         // Update only one custom layout
 
         // given a custom layout with two profiles
-        String cyclingProfile = "cycling;2;"
-                + context.getString(R.string.stats_custom_layout_moving_time_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_distance_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_average_moving_speed_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_speed_key) + ",1,1;";
-
-        String runningProfile = "running;2;"
-                + context.getString(R.string.stats_custom_layout_moving_time_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_distance_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_average_pace_key) + ",0,0;"
-                + context.getString(R.string.stats_custom_layout_pace_key) + ",0,0;";
+        String cyclingProfile = createProfileString("cycling", true);
+        String runningProfile = createProfileString("running", false);
 
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         SharedPreferences.Editor editor = sharedPreferences.edit();
@@ -298,11 +288,7 @@ public class PreferencesUtilsTest {
         List<RecordingLayout> layoutsBefore = PreferencesUtils.getAllCustomLayouts();
 
         // when cyling profile is updated
-        String cyclingProfileUpdated = "cycling;2;"
-                + context.getString(R.string.stats_custom_layout_moving_time_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_distance_key) + ",0,0;"
-                + context.getString(R.string.stats_custom_layout_average_moving_speed_key) + ",0,0;"
-                + context.getString(R.string.stats_custom_layout_speed_key) + ",0,0;";
+        String cyclingProfileUpdated = createUpdatedProfileString("cycling");
         RecordingLayout recordingLayoutToBeUpdated = RecordingLayoutIO.fromCsv(cyclingProfileUpdated, resources);
         PreferencesUtils.updateCustomLayout(recordingLayoutToBeUpdated);
 
@@ -319,18 +305,9 @@ public class PreferencesUtilsTest {
     @Test
     public void testGetCustomLayout_whenSelectedOneNotExists() {
         // given a custom layout with two profiles and not existing custom layout selected
-        String cyclingProfile = "cycling;2;"
-                + context.getString(R.string.stats_custom_layout_moving_time_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_distance_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_average_moving_speed_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_speed_key) + ",1,1;";
-
-        String runningProfile = "running;2;"
-                + context.getString(R.string.stats_custom_layout_moving_time_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_distance_key) + ",1,1;"
-                + context.getString(R.string.stats_custom_layout_average_pace_key) + ",0,0;"
-                + context.getString(R.string.stats_custom_layout_pace_key) + ",0,0;";
-
+        String cyclingProfile = createProfileString("cycling", true);
+        String runningProfile = createProfileString("running", false);
+        
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putString(context.getString(R.string.stats_custom_layouts_key), cyclingProfile + "\n" + runningProfile);


### PR DESCRIPTION
### Summary
This PR refactors the `PreferencesUtilsTest` file by extracting duplicated profile string creation logic into a helper method.

### Changes Made
- Extracted common profile string creation logic into a helper method `createProfileString()`.
<img width="468" alt="image" src="https://github.com/user-attachments/assets/c0691901-352b-4e2b-9302-217875dc9b2d" />

- Updated test cases (`testEditCustomLayouts`, `testEditCustomLayout`, and `testGetCustomLayout_whenSelectedOneNotExists`) to use the helper function.
<img width="468" alt="image" src="https://github.com/user-attachments/assets/124779a7-dd27-4774-8fdd-6ab3d312dbf0" />
<img width="468" alt="image" src="https://github.com/user-attachments/assets/db32daaf-e26e-4970-8d3e-af61f3deb170" />
<img width="468" alt="image" src="https://github.com/user-attachments/assets/30cbbeb5-4874-438c-b6ce-245333f14a44" />
<img width="468" alt="image" src="https://github.com/user-attachments/assets/6a4214a1-a77e-49cc-9ab4-9f27fa202a8b" />

- Improved code maintainability and reduced redundancy.

### Affected Files
- `src/androidTest/java/de/dennisguse/opentracks/settings/PreferencesUtilsTest.java`

### Why This Change?
- Removes duplicate code.
- Enhances readability and maintainability.
- Makes future modifications easier.

### Testing
- Ran `./gradlew testReproducibleDebugUnitTest --tests "de.dennisguse.opentracks.settings.PreferencesUtilsTest"` successfully.
<img width="468" alt="image" src="https://github.com/user-attachments/assets/c40c26ac-7850-41a2-835a-ea4041f94a1d" />

- Verified that all test cases pass without any functionality changes.

### Related Issue
- Issue: **#17**
