### PR TITLE
Refactor: Remove duplicate code in CSVTrackExporter.java and GPXTrackExporter.java

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/CSVTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/CSVTrackExporter.java
@@ -47,38 +47,6 @@ public class CSVTrackExporter implements TrackExporter {
 
     private static final String TAG = CSVTrackExporter.class.getSimpleName();
 
-    private static final NumberFormat ALTITUDE_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat COORDINATE_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat SPEED_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat DISTANCE_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat HEARTRATE_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat CADENCE_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat POWER_FORMAT = NumberFormat.getInstance(Locale.US);
-
-    static {
-        ALTITUDE_FORMAT.setMaximumFractionDigits(1);
-        ALTITUDE_FORMAT.setGroupingUsed(false);
-
-        COORDINATE_FORMAT.setMaximumFractionDigits(6);
-        COORDINATE_FORMAT.setMaximumIntegerDigits(3);
-        COORDINATE_FORMAT.setGroupingUsed(false);
-
-        SPEED_FORMAT.setMaximumFractionDigits(2);
-        SPEED_FORMAT.setGroupingUsed(false);
-
-        DISTANCE_FORMAT.setMaximumFractionDigits(0);
-        DISTANCE_FORMAT.setGroupingUsed(false);
-
-        HEARTRATE_FORMAT.setMaximumFractionDigits(0);
-        HEARTRATE_FORMAT.setGroupingUsed(false);
-
-        CADENCE_FORMAT.setMaximumFractionDigits(0);
-        CADENCE_FORMAT.setGroupingUsed(false);
-
-        POWER_FORMAT.setMaximumFractionDigits(0);
-        POWER_FORMAT.setGroupingUsed(false);
-    }
-
     private final ContentProviderUtils contentProviderUtils;
 
     private PrintWriter printWriter;
@@ -92,19 +60,19 @@ public class CSVTrackExporter implements TrackExporter {
         List<Column> columns = List.of(
                 new Column("time", null),
                 new Column("trackpoint_type", t -> quote(t.getType().name())),
-                new Column("latitude", t -> t.hasLocation() ? COORDINATE_FORMAT.format(t.getLatitude()) : ""),
-                new Column("longitude", t -> t.hasLocation() ? COORDINATE_FORMAT.format(t.getLongitude()) : ""),
-                new Column("altitude", t -> t.hasAltitude() ? COORDINATE_FORMAT.format(t.getAltitude().toM()) : ""),
-                new Column("accuracy_horizontal", t -> t.hasHorizontalAccuracy() ? DISTANCE_FORMAT.format(t.getHorizontalAccuracy().toM()) : ""),
-                new Column("accuracy_vertical", t -> t.hasVerticalAccuracy() ? DISTANCE_FORMAT.format(t.getVerticalAccuracy().toM()) : ""),
-
-                new Column("speed", t -> t.hasSpeed() ? SPEED_FORMAT.format(t.getSpeed().toKMH()) : ""),
-                new Column("altitude_gain", t -> t.hasAltitudeGain() ? DISTANCE_FORMAT.format(t.getAltitudeGain()) : ""),
-                new Column("altitude_loss", t -> t.hasAltitudeLoss() ? DISTANCE_FORMAT.format(t.getAltitudeLoss()) : ""),
-                new Column("sensor_distance", t -> t.hasSensorDistance() ? DISTANCE_FORMAT.format(t.getSensorDistance().toM()) : ""),
-                new Column("heartrate", t -> t.hasHeartRate() ? HEARTRATE_FORMAT.format(t.getHeartRate().getBPM()) : ""),
-                new Column("cadence", t -> t.hasCadence() ? CADENCE_FORMAT.format(t.getCadence().getRPM()) : ""),
-                new Column("power", t -> t.hasPower() ? ALTITUDE_FORMAT.format(t.getPower().getW()) : ""));
+                new Column("latitude", t -> t.hasLocation() ? TrackExporterUtils.COORDINATE_FORMAT.format(t.getLatitude()) : ""),
+                new Column("longitude", t -> t.hasLocation() ? TrackExporterUtils.COORDINATE_FORMAT.format(t.getLongitude()) : ""),
+                new Column("altitude", t -> t.hasAltitude() ? TrackExporterUtils.ALTITUDE_FORMAT.format(t.getAltitude().toM()) : ""),
+                new Column("accuracy_horizontal", t -> t.hasHorizontalAccuracy() ? TrackExporterUtils.DISTANCE_FORMAT.format(t.getHorizontalAccuracy().toM()) : ""),
+                new Column("accuracy_vertical", t -> t.hasVerticalAccuracy() ? TrackExporterUtils.DISTANCE_FORMAT.format(t.getVerticalAccuracy().toM()) : ""),
+                new Column("speed", t -> t.hasSpeed() ? TrackExporterUtils.SPEED_FORMAT.format(t.getSpeed().toKMH()) : ""),
+                new Column("altitude_gain", t -> t.hasAltitudeGain() ? TrackExporterUtils.DISTANCE_FORMAT.format(t.getAltitudeGain()) : ""),
+                new Column("altitude_loss", t -> t.hasAltitudeLoss() ? TrackExporterUtils.DISTANCE_FORMAT.format(t.getAltitudeLoss()) : ""),
+                new Column("sensor_distance", t -> t.hasSensorDistance() ? TrackExporterUtils.DISTANCE_FORMAT.format(t.getSensorDistance().toM()) : ""),
+                new Column("heartrate", t -> t.hasHeartRate() ? TrackExporterUtils.HEARTRATE_FORMAT.format(t.getHeartRate().getBPM()) : ""),
+                new Column("cadence", t -> t.hasCadence() ? TrackExporterUtils.CADENCE_FORMAT.format(t.getCadence().getRPM()) : ""),
+                new Column("power", t -> t.hasPower() ? TrackExporterUtils.POWER_FORMAT.format(t.getPower().getW()) : "")
+        );
 
         try {
             prepare(outputStream);

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
@@ -54,39 +54,6 @@ public class GPXTrackExporter implements TrackExporter {
 
     private static final String TAG = GPXTrackExporter.class.getSimpleName();
 
-    private static final NumberFormat ALTITUDE_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat COORDINATE_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat SPEED_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat DISTANCE_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat HEARTRATE_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat CADENCE_FORMAT = NumberFormat.getInstance(Locale.US);
-    private static final NumberFormat POWER_FORMAT = NumberFormat.getInstance(Locale.US);
-
-    static {
-        /*
-         * GPX readers expect to see fractional numbers with US-style punctuation.
-         * That is, they want periods for decimal points, rather than commas.
-         */
-        ALTITUDE_FORMAT.setMaximumFractionDigits(1);
-        ALTITUDE_FORMAT.setGroupingUsed(false);
-
-        COORDINATE_FORMAT.setMaximumFractionDigits(6);
-        COORDINATE_FORMAT.setMaximumIntegerDigits(3);
-        COORDINATE_FORMAT.setGroupingUsed(false);
-
-        SPEED_FORMAT.setMaximumFractionDigits(2);
-        SPEED_FORMAT.setGroupingUsed(false);
-
-        HEARTRATE_FORMAT.setMaximumFractionDigits(0);
-        HEARTRATE_FORMAT.setGroupingUsed(false);
-
-        CADENCE_FORMAT.setMaximumFractionDigits(0);
-        CADENCE_FORMAT.setGroupingUsed(false);
-
-        POWER_FORMAT.setMaximumFractionDigits(0);
-        POWER_FORMAT.setGroupingUsed(false);
-    }
-
     private final ContentProviderUtils contentProviderUtils;
 
     private final String creator;
@@ -256,7 +223,7 @@ public class GPXTrackExporter implements TrackExporter {
     public void writeMarker(ZoneOffset zoneOffset, Marker marker) {
         printWriter.println("<wpt " + formatLocation(marker.getLatitude(), marker.getLongitude()) + ">");
         if (marker.hasAltitude()) {
-            printWriter.println("<ele>" + ALTITUDE_FORMAT.format(marker.getAltitude().toM()) + "</ele>");
+            printWriter.println("<ele>" + TrackExporterUtils.ALTITUDE_FORMAT.format(marker.getAltitude().toM()) + "</ele>");
         }
         printWriter.println("<time>" + StringUtils.formatDateTimeIso8601(marker.getTime(), zoneOffset) + "</time>");
         printWriter.println("<name>" + StringUtils.formatCData(marker.getName()) + "</name>");
@@ -315,7 +282,7 @@ public class GPXTrackExporter implements TrackExporter {
         printWriter.println("<trkpt " + formatLocation(trackPoint.getLatitude(), trackPoint.getLongitude()) + ">");
 
         if (trackPoint.hasAltitude()) {
-            printWriter.println("<ele>" + ALTITUDE_FORMAT.format(trackPoint.getAltitude().toM()) + "</ele>");
+            printWriter.println("<ele>" + TrackExporterUtils.ALTITUDE_FORMAT.format(trackPoint.getAltitude().toM()) + "</ele>");
         }
 
         printWriter.println("<time>" + StringUtils.formatDateTimeIso8601(trackPoint.getTime(), zoneOffset) + "</time>");
@@ -324,42 +291,42 @@ public class GPXTrackExporter implements TrackExporter {
             String trackPointExtensionContent = "";
 
             if (trackPoint.hasSpeed()) {
-                trackPointExtensionContent += "<gpxtpx:speed>" + SPEED_FORMAT.format(trackPoint.getSpeed().toMPS()) + "</gpxtpx:speed>\n";
+                trackPointExtensionContent += "<gpxtpx:speed>" + TrackExporterUtils.SPEED_FORMAT.format(trackPoint.getSpeed().toMPS()) + "</gpxtpx:speed>\n";
             }
 
             if (trackPoint.hasHeartRate()) {
-                trackPointExtensionContent += "<gpxtpx:hr>" + HEARTRATE_FORMAT.format(trackPoint.getHeartRate().getBPM()) + "</gpxtpx:hr>\n";
+                trackPointExtensionContent += "<gpxtpx:hr>" + TrackExporterUtils.HEARTRATE_FORMAT.format(trackPoint.getHeartRate().getBPM()) + "</gpxtpx:hr>\n";
             }
 
             if (trackPoint.hasCadence()) {
-                trackPointExtensionContent += "<gpxtpx:cad>" + CADENCE_FORMAT.format(trackPoint.getCadence().getRPM()) + "</gpxtpx:cad>\n";
+                trackPointExtensionContent += "<gpxtpx:cad>" + TrackExporterUtils.CADENCE_FORMAT.format(trackPoint.getCadence().getRPM()) + "</gpxtpx:cad>\n";
             }
 
             if (trackPoint.hasPower()) {
-                trackPointExtensionContent += "<pwr:PowerInWatts>" + POWER_FORMAT.format(trackPoint.getPower().getW()) + "</pwr:PowerInWatts>\n";
+                trackPointExtensionContent += "<pwr:PowerInWatts>" + TrackExporterUtils.POWER_FORMAT.format(trackPoint.getPower().getW()) + "</pwr:PowerInWatts>\n";
             }
 
             Double cumulativeGain = cumulateSensorData(trackPoint, sensorPoints, (tp) -> tp.hasAltitudeGain() ? (double) tp.getAltitudeGain() : null);
             if (cumulativeGain != null) {
-                trackPointExtensionContent += ("<opentracks:gain>" + ALTITUDE_FORMAT.format(cumulativeGain) + "</opentracks:gain>\n");
+                trackPointExtensionContent += ("<opentracks:gain>" + TrackExporterUtils.ALTITUDE_FORMAT.format(cumulativeGain) + "</opentracks:gain>\n");
             }
 
             Double cumulativeLoss = cumulateSensorData(trackPoint, sensorPoints, (tp) -> tp.hasAltitudeLoss() ? (double) tp.getAltitudeLoss() : null);
             if (cumulativeLoss != null) {
-                trackPointExtensionContent += ("<opentracks:loss>" + ALTITUDE_FORMAT.format(cumulativeLoss) + "</opentracks:loss>\n");
+                trackPointExtensionContent += ("<opentracks:loss>" + TrackExporterUtils.ALTITUDE_FORMAT.format(cumulativeLoss) + "</opentracks:loss>\n");
             }
 
             if (trackPoint.hasHorizontalAccuracy()) {
-                trackPointExtensionContent += ("<opentracks:accuracy_horizontal>" + DISTANCE_FORMAT.format(trackPoint.getHorizontalAccuracy().toM()) + "</opentracks:accuracy_horizontal>");
+                trackPointExtensionContent += ("<opentracks:accuracy_horizontal>" + TrackExporterUtils.DISTANCE_FORMAT.format(trackPoint.getHorizontalAccuracy().toM()) + "</opentracks:accuracy_horizontal>");
             }
             if (trackPoint.hasVerticalAccuracy()) {
-                trackPointExtensionContent += ("<opentracks:accuracy_vertical>" + DISTANCE_FORMAT.format(trackPoint.getVerticalAccuracy().toM()) + "</opentracks:accuracy_vertical>");
+                trackPointExtensionContent += ("<opentracks:accuracy_vertical>" + TrackExporterUtils.DISTANCE_FORMAT.format(trackPoint.getVerticalAccuracy().toM()) + "</opentracks:accuracy_vertical>");
             }
 
             cumulativeDistance = Distance.ofOrNull(cumulateSensorData(trackPoint, sensorPoints, (tp) -> tp.hasSensorDistance() ? tp.getSensorDistance().toM() : null));
             if (cumulativeDistance != null) {
-                trackPointExtensionContent += ("<opentracks:distance>" + DISTANCE_FORMAT.format(cumulativeDistance.toM()) + "</opentracks:distance>\n");
-                trackPointExtensionContent += ("<cluetrust:distance>" + DISTANCE_FORMAT.format(trackDistance.plus(cumulativeDistance).toM()) + "</cluetrust:distance>\n");
+                trackPointExtensionContent += ("<opentracks:distance>" + TrackExporterUtils.DISTANCE_FORMAT.format(cumulativeDistance.toM()) + "</opentracks:distance>\n");
+                trackPointExtensionContent += ("<cluetrust:distance>" + TrackExporterUtils.DISTANCE_FORMAT.format(trackDistance.plus(cumulativeDistance).toM()) + "</cluetrust:distance>\n");
             }
 
             if (!trackPointExtensionContent.isEmpty()) {
@@ -386,6 +353,6 @@ public class GPXTrackExporter implements TrackExporter {
     }
 
     private String formatLocation(double latitude, double longitude) {
-        return "lat=\"" + COORDINATE_FORMAT.format(latitude) + "\" lon=\"" + COORDINATE_FORMAT.format(longitude) + "\"";
+        return "lat=\"" + TrackExporterUtils.COORDINATE_FORMAT.format(latitude) + "\" lon=\"" + TrackExporterUtils.COORDINATE_FORMAT.format(longitude) + "\"";
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/TrackExporterUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/TrackExporterUtils.java
@@ -1,0 +1,28 @@
+package de.dennisguse.opentracks.io.file.exporter;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+
+public class TrackExporterUtils {
+
+    public static final NumberFormat ALTITUDE_FORMAT = createNumberFormat(1);
+    public static final NumberFormat COORDINATE_FORMAT = createNumberFormat(6, 3);
+    public static final NumberFormat SPEED_FORMAT = createNumberFormat(2);
+    public static final NumberFormat DISTANCE_FORMAT = createNumberFormat(0);
+    public static final NumberFormat HEARTRATE_FORMAT = createNumberFormat(0);
+    public static final NumberFormat CADENCE_FORMAT = createNumberFormat(0);
+    public static final NumberFormat POWER_FORMAT = createNumberFormat(0);
+
+    private static NumberFormat createNumberFormat(int maximumFractionDigits) {
+        NumberFormat format = NumberFormat.getInstance(Locale.US);
+        format.setMaximumFractionDigits(maximumFractionDigits);
+        format.setGroupingUsed(false);
+        return format;
+    }
+
+    private static NumberFormat createNumberFormat(int maximumFractionDigits, int maximumIntegerDigits) {
+        NumberFormat format = createNumberFormat(maximumFractionDigits);
+        format.setMaximumIntegerDigits(maximumIntegerDigits);
+        return format;
+    }
+}


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses the duplicated code between CSVTrackExporter.java and GPXTrackExporter.java files. To remove the duplicated code, i have created an utility class to initialize and configure the NumberFormat instances. This will centralize the configuration logic and make it easier to maintain.
By using this refactoring it will eliminates redundant code, reducing duplication and also enhances readability and improves maintainability. Both exporters will use the same formatting rules, ensuring consistency across the application.
**Link to the the issue**
https://github.com/saumyaa03/OpenTracksW25Group7/issues/29
Main repo: https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/35
**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
