### PR TITLE
Fix Path Traversal in ‎KMZTrackImporter.java 

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
@@ -235,8 +235,14 @@ public class KmzTrackImporter {
             return;
         }
 
+        fileName = sanitizeFilename(fileName);
+
         File dir = FileUtils.getPhotoDir(context, trackId);
         File file = new File(dir, fileName);
+        if (!file.getCanonicalPath().startsWith(dir.getCanonicalPath())) {
+            throw new SecurityException("Attempted path traversal attack");
+        }
+    
 
         try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -249,5 +255,16 @@ public class KmzTrackImporter {
                 }
             }
         }
+    }
+
+    private String sanitizeFilename(String fileName) {
+        fileName = fileName.replace("../", "_")
+                          .replace("./", "_")
+                          .replace("/", "_")
+                          .replace("\\", "_");
+    
+        fileName = fileName.replaceAll("[^a-zA-Z0-9.-]", "_");
+    
+        return fileName;
     }
 }


### PR DESCRIPTION
**Describe the pull request**
Fixed path traversal vulnerability in KMZTrackImporter.java . Previously it used allow the input from a zip file flows into java.io.FileOutputStream, where it is used as a path which may result in a Path Traversal vulnerability and allow an attacker to write to arbitrary files. 
Now, I sanitized the file name by removing ../, ./, /, and \ (path traversal sequences) and replacing them with underscores (_). I have also removed any other potentially dangerous characters. I also ensured that final file path does not escape the intended directory (FileUtils.getPhotoDir())
This will sanitize the filename, so that an attacker cannot use ../ to escape the target directory and also using getCanonicalPath() check adds an extra layer of security.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
